### PR TITLE
Basic editorconfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+# 2 space indentation
+[*.py]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Almost every IDE or texteditor supports
[editorconfig](https://editorconfig.org/).
I've set it up to just enforce the 2 space python indents for now.